### PR TITLE
Update to AsyncKeyedLock 6.2.0

### DIFF
--- a/src/Bundler/Bundler.csproj
+++ b/src/Bundler/Bundler.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncKeyedLock, Version=6.1.1.0, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AsyncKeyedLock.6.1.1\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
+    <Reference Include="AsyncKeyedLock, Version=6.2.0.0, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AsyncKeyedLock.6.2.0\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
     </Reference>
     <Reference Include="dotless.Core, Version=1.5.2.0, Culture=neutral, PublicKeyToken=96b446c9e63eae34, processorArchitecture=MSIL">
       <HintPath>..\..\packages\dotless.1.5.2\lib\dotless.Core.dll</HintPath>

--- a/src/Bundler/packages.config
+++ b/src/Bundler/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AsyncKeyedLock" version="6.2.0" targetFramework="net462" />
   <package id="dotless" version="1.5.2" targetFramework="net462" />
   <package id="JavaScriptEngineSwitcher.Core" version="2.4.10" targetFramework="net462" />
   <package id="libsassnet" version="3.3.7" targetFramework="net462" />


### PR DESCRIPTION
This version now provides an alternate technique called striped locking. With this PR, nothing changes in the way things are done, but if you would like to check out the advantages and disadvantages of the new mechanism, please read up on it at https://github.com/MarkCiliaVincenti/AsyncKeyedLock/wiki